### PR TITLE
add support for extended sharepoint base url

### DIFF
--- a/getNotebooks.py
+++ b/getNotebooks.py
@@ -75,6 +75,8 @@ def main(wf):
             urlbase = url[0] + "//" + url[2] + "/" + url[3] + "/" + url[4] + "/"
             # write to plist
             plistlib.writePlist({"urlbase": urlbase}, SETTINGS_PATH)
+            if "sharepoint" in url[2]:
+                urlbase += url[5] + "/"
             # tell alfred how to display a success notification
             print("true")
         else:


### PR DESCRIPTION
fixes most common problem causing issue #4 
Notebooks stored on the Sharepoint servers have an extra url part
